### PR TITLE
Raise error when requesting install for non-existent versions

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -8,7 +8,7 @@ set -euo pipefail
 
 install() {
   local install_type=$1
-  [ "$install_type" != "version" ] && echo "intall type, $install_type, is not supported" && exit 1
+  [ "$install_type" != "version" ] && echo "install type, $install_type, is not supported" && exit 1
 
   local version=$2
   local install_path=$3

--- a/bin/install
+++ b/bin/install
@@ -27,9 +27,16 @@ install() {
   mkdir -p "${bin_install_path}"
 
   echo "Downloading terragrunt from ${download_url}"
-  curl -sL "$download_url" -o "$bin_path"
+
+  STATUSCODE=$(curl --write-out "%{http_code}" -Lo "$bin_path" -C - "$download_url")
+
+  if test "${STATUSCODE}" -ne 200; then
+    echo "Binary for version '${version}' was not found or could not be retrieved."
+    exit 1
+  fi
+
   chmod +x "$bin_path"
 }
 
-install "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH" 
+install "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
 


### PR DESCRIPTION
Previously this plugin allowed the installation of versions that didn't exist, e.g.:

`asdf install terragrunt foobar`

which would result in having a bogus file with "Not found", instead of a valid Terragrunt binary.

Therefore, we do a simple check to ensure the status of the request is 200, otherwise we error out.